### PR TITLE
Upgrade gradle-wrapper-validation action from v1 to v4

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -10,4 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v4


### PR DESCRIPTION
## Summary
  The `gradle/wrapper-validation-action@v1` action validates the repo's                                                                                                                       
  `gradle/wrapper/gradle-wrapper.jar` against an expected checksum it derives                                                                                                                 
  on the fly by hitting URLs like                                                                                                                                                             
  `services.gradle.org/distributions/gradle-X.Y.Z-wrapper.jar`. Those URLs                                                                                                                    
  return **404** for the 7.6.3 wrapper that this branch uses (and for older                                                                                                                   
  Gradle releases generally), so the action fails for every fork that runs                                                                                                                    
  the workflow — even though the wrapper.jar in this repo is the official one                                                                                                                 
  extracted from the upstream Gradle 7.6.3 distribution                                                                                                                                       
  (`gradle-7.6.3-bin.zip` → `lib/plugins/gradle-wrapper-7.6.3.jar` →                                                                                                                          
  `gradle-wrapper.jar`, SHA-256                                                                                                                                                               
  `14dfa961b6704bb3decdea06502781edaa796a82e6da41cd2e1962b14fbe21a3`).                                                                                                                        
                                                                                                                                                                                              
  `gradle/actions/wrapper-validation@v4` uses a maintained checksum list                                                                                                                      
  instead and accepts the existing wrapper without modification.                                                                                                                              
                                                                                                                                                                                              
  ## Test plan                                                                                                                                                                                
  - [ ] Once merged, the "Validate Gradle Wrapper" workflow run on subsequent                                                                                                                 
        pushes to `2.7.x` (and on the open `task/PVADMIN-49830` PR) goes green. 