### PR TITLE
PVADMIN-49853: Fix CVE-2026-40971/3/4/5/7 in spring-boot (2.7.18-rxlogix-3)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.7.18-rxlogix-2
+version=2.7.18-rxlogix-3
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.7.18-rxlogix-1
+version=2.7.18-rxlogix-2
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/CloudFoundryWebFluxEndpointHandlerMapping.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/CloudFoundryWebFluxEndpointHandlerMapping.java
@@ -70,6 +70,12 @@ class CloudFoundryWebFluxEndpointHandlerMapping extends AbstractWebFluxEndpointH
 	}
 
 	@Override
+	protected void initHandlerMethods() {
+		super.initHandlerMethods();
+		registerCatchAllMapping(HttpStatus.FORBIDDEN);
+	}
+
+	@Override
 	protected ReactiveWebOperation wrapReactiveWebOperation(ExposableWebEndpoint endpoint, WebOperation operation,
 			ReactiveWebOperation reactiveWebOperation) {
 		return new SecureReactiveWebOperation(reactiveWebOperation, this.securityInterceptor, endpoint.getEndpointId());

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveCloudFoundryActuatorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveCloudFoundryActuatorAutoConfiguration.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.BeansException;
@@ -37,7 +36,6 @@ import org.springframework.boot.actuate.endpoint.invoke.ParameterValueMapper;
 import org.springframework.boot.actuate.endpoint.web.EndpointMapping;
 import org.springframework.boot.actuate.endpoint.web.EndpointMediaTypes;
 import org.springframework.boot.actuate.endpoint.web.ExposableWebEndpoint;
-import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
 import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointsSupplier;
 import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.actuate.health.ReactiveHealthEndpointWebExtension;
@@ -65,7 +63,6 @@ import org.springframework.security.web.server.MatcherSecurityWebFilterChain;
 import org.springframework.security.web.server.WebFilterChainProxy;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
-import org.springframework.util.function.SingletonSupplier;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.WebFilter;
@@ -157,48 +154,34 @@ public class ReactiveCloudFoundryActuatorAutoConfiguration {
 	static class IgnoredPathsSecurityConfiguration {
 
 		@Bean
-		static WebFilterChainPostProcessor webFilterChainPostProcessor(
-				ObjectProvider<CloudFoundryWebFluxEndpointHandlerMapping> handlerMapping) {
-			return new WebFilterChainPostProcessor(handlerMapping);
+		static WebFilterChainPostProcessor webFilterChainPostProcessor() {
+			return new WebFilterChainPostProcessor();
 		}
 
 	}
 
 	static class WebFilterChainPostProcessor implements BeanPostProcessor {
 
-		private final Supplier<PathMappedEndpoints> pathMappedEndpoints;
-
-		WebFilterChainPostProcessor(ObjectProvider<CloudFoundryWebFluxEndpointHandlerMapping> handlerMapping) {
-			this.pathMappedEndpoints = SingletonSupplier
-				.of(() -> new PathMappedEndpoints(BASE_PATH, () -> handlerMapping.getObject().getAllEndpoints()));
+		WebFilterChainPostProcessor() {
 		}
 
 		@Override
 		public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
 			if (bean instanceof WebFilterChainProxy) {
-				return postProcess((WebFilterChainProxy) bean, this.pathMappedEndpoints.get());
+				return postProcess((WebFilterChainProxy) bean);
 			}
 			return bean;
 		}
 
-		private WebFilterChainProxy postProcess(WebFilterChainProxy existing, PathMappedEndpoints pathMappedEndpoints) {
-			List<String> paths = getPaths(pathMappedEndpoints);
+		private WebFilterChainProxy postProcess(WebFilterChainProxy existing) {
 			ServerWebExchangeMatcher cloudFoundryRequestMatcher = ServerWebExchangeMatchers
-				.pathMatchers(paths.toArray(new String[] {}));
+				.pathMatchers(BASE_PATH + "/**");
 			WebFilter noOpFilter = (exchange, chain) -> chain.filter(exchange);
 			MatcherSecurityWebFilterChain ignoredRequestFilterChain = new MatcherSecurityWebFilterChain(
 					cloudFoundryRequestMatcher, Collections.singletonList(noOpFilter));
 			MatcherSecurityWebFilterChain allRequestsFilterChain = new MatcherSecurityWebFilterChain(
 					ServerWebExchangeMatchers.anyExchange(), Collections.singletonList(existing));
 			return new WebFilterChainProxy(ignoredRequestFilterChain, allRequestsFilterChain);
-		}
-
-		private static List<String> getPaths(PathMappedEndpoints pathMappedEndpoints) {
-			List<String> paths = new ArrayList<>();
-			pathMappedEndpoints.getAllPaths().forEach((path) -> paths.add(path + "/**"));
-			paths.add(BASE_PATH);
-			paths.add(BASE_PATH + "/");
-			return paths;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryActuatorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryActuatorAutoConfiguration.java
@@ -34,7 +34,6 @@ import org.springframework.boot.actuate.endpoint.invoke.ParameterValueMapper;
 import org.springframework.boot.actuate.endpoint.web.EndpointMapping;
 import org.springframework.boot.actuate.endpoint.web.EndpointMediaTypes;
 import org.springframework.boot.actuate.endpoint.web.ExposableWebEndpoint;
-import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
 import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointsSupplier;
 import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointsSupplier;
 import org.springframework.boot.actuate.health.HealthEndpoint;
@@ -66,9 +65,6 @@ import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.security.web.util.matcher.OrRequestMatcher;
-import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.util.CollectionUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.servlet.DispatcherServlet;
 
@@ -167,9 +163,8 @@ public class CloudFoundryActuatorAutoConfiguration {
 	public static class IgnoredCloudFoundryPathsWebSecurityConfiguration {
 
 		@Bean
-		IgnoredCloudFoundryPathsWebSecurityCustomizer ignoreCloudFoundryPathsWebSecurityCustomizer(
-				CloudFoundryWebEndpointServletHandlerMapping handlerMapping) {
-			return new IgnoredCloudFoundryPathsWebSecurityCustomizer(handlerMapping);
+		IgnoredCloudFoundryPathsWebSecurityCustomizer ignoreCloudFoundryPathsWebSecurityCustomizer() {
+			return new IgnoredCloudFoundryPathsWebSecurityCustomizer();
 		}
 
 	}
@@ -177,22 +172,12 @@ public class CloudFoundryActuatorAutoConfiguration {
 	@Order(SecurityProperties.IGNORED_ORDER)
 	static class IgnoredCloudFoundryPathsWebSecurityCustomizer implements WebSecurityCustomizer {
 
-		private final PathMappedEndpoints pathMappedEndpoints;
-
-		IgnoredCloudFoundryPathsWebSecurityCustomizer(CloudFoundryWebEndpointServletHandlerMapping handlerMapping) {
-			this.pathMappedEndpoints = new PathMappedEndpoints(BASE_PATH, handlerMapping::getAllEndpoints);
+		IgnoredCloudFoundryPathsWebSecurityCustomizer() {
 		}
 
 		@Override
 		public void customize(WebSecurity web) {
-			List<RequestMatcher> requestMatchers = new ArrayList<>();
-			this.pathMappedEndpoints.getAllPaths()
-				.forEach((path) -> requestMatchers.add(new AntPathRequestMatcher(path + "/**")));
-			requestMatchers.add(new AntPathRequestMatcher(BASE_PATH));
-			requestMatchers.add(new AntPathRequestMatcher(BASE_PATH + "/"));
-			if (!CollectionUtils.isEmpty(requestMatchers)) {
-				web.ignoring().requestMatchers(new OrRequestMatcher(requestMatchers));
-			}
+			web.ignoring().requestMatchers(new AntPathRequestMatcher(BASE_PATH + "/**"));
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryWebEndpointServletHandlerMapping.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryWebEndpointServletHandlerMapping.java
@@ -76,6 +76,12 @@ class CloudFoundryWebEndpointServletHandlerMapping extends AbstractWebMvcEndpoin
 	}
 
 	@Override
+	protected void initHandlerMethods() {
+		super.initHandlerMethods();
+		registerCatchAllMapping(HttpStatus.FORBIDDEN);
+	}
+
+	@Override
 	protected ServletWebOperation wrapServletWebOperation(ExposableWebEndpoint endpoint, WebOperation operation,
 			ServletWebOperation servletWebOperation) {
 		return new SecureServletWebOperation(servletWebOperation, this.securityInterceptor, endpoint.getEndpointId());

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/CloudFoundryWebFluxEndpointIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/CloudFoundryWebFluxEndpointIntegrationTests.java
@@ -210,6 +210,12 @@ class CloudFoundryWebFluxEndpointIntegrationTests {
 			.doesNotExist()));
 	}
 
+	@Test
+	void unknownEndpointsAreForbidden() {
+		this.contextRunner.run(withWebTestClient(
+				(client) -> client.get().uri("/cfApplication/unknown").exchange().expectStatus().isForbidden()));
+	}
+
 	private ContextConsumer<AssertableReactiveWebApplicationContext> withWebTestClient(
 			Consumer<WebTestClient> clientConsumer) {
 		return (context) -> {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveCloudFoundryActuatorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveCloudFoundryActuatorAutoConfigurationTests.java
@@ -195,7 +195,7 @@ class ReactiveCloudFoundryActuatorAutoConfigurationTests {
 				assertThat(cfBaseWithTrailingSlashRequestMatches).isTrue();
 				assertThat(cfRequestMatches).isTrue();
 				assertThat(cfRequestWithAdditionalPathMatches).isTrue();
-				assertThat(otherCfRequestMatches).isFalse();
+				assertThat(otherCfRequestMatches).isTrue();
 				assertThat(otherRequestMatches).isFalse();
 				otherRequestMatches = filters.get(1)
 					.matches(MockServerWebExchange.from(MockServerHttpRequest.get("/some-other-path").build()))

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryActuatorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryActuatorAutoConfigurationTests.java
@@ -182,8 +182,7 @@ class CloudFoundryActuatorAutoConfigurationTests {
 				testCloudFoundrySecurity(request, BASE_PATH + "/", chain);
 				testCloudFoundrySecurity(request, BASE_PATH + "/test", chain);
 				testCloudFoundrySecurity(request, BASE_PATH + "/test/a", chain);
-				request.setServletPath(BASE_PATH + "/other-path");
-				assertThat(chain.matches(request)).isFalse();
+				testCloudFoundrySecurity(request, BASE_PATH + "/other-path", chain);
 				request.setServletPath("/some-other-path");
 				assertThat(chain.matches(request)).isFalse();
 			});

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryMvcWebEndpointIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryMvcWebEndpointIntegrationTests.java
@@ -199,6 +199,17 @@ class CloudFoundryMvcWebEndpointIntegrationTests {
 					.doesNotExist());
 	}
 
+	@Test
+	void unknownEndpointsAreForbidden() {
+		load(TestEndpointConfiguration.class,
+				(client) -> client.get()
+					.uri("/cfApplication/unknown")
+					.accept(MediaType.APPLICATION_JSON)
+					.exchange()
+					.expectStatus()
+					.isForbidden());
+	}
+
 	private void load(Class<?> configuration, Consumer<WebTestClient> clientConsumer) {
 		BiConsumer<ApplicationContext, WebTestClient> consumer = (context, client) -> clientConsumer.accept(client);
 		new WebApplicationContextRunner(AnnotationConfigServletWebServerApplicationContext::new)

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/reactive/AbstractWebFluxEndpointHandlerMapping.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/reactive/AbstractWebFluxEndpointHandlerMapping.java
@@ -49,6 +49,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.security.access.AccessDecisionVoter;
 import org.springframework.security.access.SecurityConfig;
 import org.springframework.security.access.vote.RoleVoter;
@@ -94,6 +95,9 @@ public abstract class AbstractWebFluxEndpointHandlerMapping extends RequestMappi
 			ServerWebExchange.class, Map.class);
 
 	private final Method handleReadMethod = ReflectionUtils.findMethod(ReadOperationHandler.class, "handle",
+			ServerWebExchange.class);
+
+	private final Method handleCatchAllMethod = ReflectionUtils.findMethod(CatchAllHandler.class, "handle",
 			ServerWebExchange.class);
 
 	private final boolean shouldRegisterLinksMapping;
@@ -167,6 +171,17 @@ public abstract class AbstractWebFluxEndpointHandlerMapping extends RequestMappi
 	protected ReactiveWebOperation wrapReactiveWebOperation(ExposableWebEndpoint endpoint, WebOperation operation,
 			ReactiveWebOperation reactiveWebOperation) {
 		return reactiveWebOperation;
+	}
+
+	/**
+	 * Register a "catch all" handler for the rest of actuator namespace, ensuring that
+	 * all requests are handled by this handler mapping.
+	 * @param responseStatus the response status to use for handled requests
+	 */
+	protected void registerCatchAllMapping(HttpStatus responseStatus) {
+		String subPath = this.endpointMapping.createSubPath("/**");
+		registerMapping(RequestMappingInfo.paths(subPath).build(), new CatchAllHandler(responseStatus),
+				this.handleCatchAllMethod);
 	}
 
 	private RequestMappingInfo createRequestMappingInfo(WebOperation operation) {
@@ -440,6 +455,30 @@ public abstract class AbstractWebFluxEndpointHandlerMapping extends RequestMappi
 		@Override
 		public String toString() {
 			return this.operation.toString();
+		}
+
+	}
+
+	/**
+	 * Catch-all handler that always replies with a fixed HTTP status.
+	 */
+	private static final class CatchAllHandler {
+
+		private final HttpStatus responseStatus;
+
+		CatchAllHandler(HttpStatus responseStatus) {
+			this.responseStatus = responseStatus;
+		}
+
+		Mono<Void> handle(ServerWebExchange exchange) {
+			ServerHttpResponse response = exchange.getResponse();
+			response.setStatusCode(this.responseStatus);
+			return response.setComplete();
+		}
+
+		@Override
+		public String toString() {
+			return "Actuator catch-all endpoint";
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/servlet/AbstractWebMvcEndpointHandlerMapping.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/servlet/AbstractWebMvcEndpointHandlerMapping.java
@@ -101,6 +101,9 @@ public abstract class AbstractWebMvcEndpointHandlerMapping extends RequestMappin
 	private final Method handleMethod = ReflectionUtils.findMethod(OperationHandler.class, "handle",
 			HttpServletRequest.class, Map.class);
 
+	private final Method catchAllMethod = ReflectionUtils.findMethod(CatchAllHandler.class, "handle",
+			HttpServletResponse.class);
+
 	private RequestMappingInfo.BuilderConfiguration builderConfig = new RequestMappingInfo.BuilderConfiguration();
 
 	/**
@@ -231,6 +234,17 @@ public abstract class AbstractWebMvcEndpointHandlerMapping extends RequestMappin
 	protected ServletWebOperation wrapServletWebOperation(ExposableWebEndpoint endpoint, WebOperation operation,
 			ServletWebOperation servletWebOperation) {
 		return servletWebOperation;
+	}
+
+	/**
+	 * Register a "catch all" handler for the rest of actuator namespace, ensuring that
+	 * all requests are handled by this handler mapping.
+	 * @param responseStatus the response status to use for handled requests
+	 */
+	protected void registerCatchAllMapping(HttpStatus responseStatus) {
+		String subPath = this.endpointMapping.createSubPath("/**");
+		registerMapping(RequestMappingInfo.paths(subPath).options(this.builderConfig).build(),
+				new CatchAllHandler(responseStatus), this.catchAllMethod);
 	}
 
 	private RequestMappingInfo createRequestMappingInfo(WebOperationRequestPredicate predicate, String path) {
@@ -467,6 +481,23 @@ public abstract class AbstractWebMvcEndpointHandlerMapping extends RequestMappin
 		@Override
 		public String toString() {
 			return this.operation.toString();
+		}
+
+	}
+
+	/**
+	 * Catch-all handler that always replies with a fixed HTTP status.
+	 */
+	private static final class CatchAllHandler {
+
+		private final HttpStatus responseStatus;
+
+		CatchAllHandler(HttpStatus responseStatus) {
+			this.responseStatus = responseStatus;
+		}
+
+		void handle(HttpServletResponse response) {
+			response.setStatus(this.responseStatus.value());
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraAutoConfiguration.java
@@ -34,6 +34,7 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.DriverOption;
 import com.datastax.oss.driver.api.core.config.ProgrammaticDriverConfigLoaderBuilder;
+import com.datastax.oss.driver.api.core.ssl.ProgrammaticSslEngineFactory;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultProgrammaticDriverConfigLoaderBuilder;
 import com.typesafe.config.Config;
@@ -110,7 +111,8 @@ public class CassandraAutoConfiguration {
 	private void configureSsl(CassandraProperties properties, CqlSessionBuilder builder) {
 		if (properties.isSsl()) {
 			try {
-				builder.withSslContext(SSLContext.getDefault());
+				builder.withSslEngineFactory(new ProgrammaticSslEngineFactory(SSLContext.getDefault(), null,
+						properties.isSslVerifyHostname()));
 			}
 			catch (NoSuchAlgorithmException ex) {
 				throw new IllegalStateException("Could not setup SSL default context for Cassandra", ex);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
@@ -94,6 +94,13 @@ public class CassandraProperties {
 	private boolean ssl = false;
 
 	/**
+	 * Whether to perform hostname verification on the server's certificate when SSL is
+	 * enabled. Disable only if you are connecting to a Cassandra cluster by IP address or
+	 * in a trusted network environment.
+	 */
+	private boolean sslVerifyHostname = true;
+
+	/**
 	 * Connection configuration.
 	 */
 	private final Connection connection = new Connection();
@@ -191,6 +198,14 @@ public class CassandraProperties {
 
 	public void setSsl(boolean ssl) {
 		this.ssl = ssl;
+	}
+
+	public boolean isSslVerifyHostname() {
+		return this.sslVerifyHostname;
+	}
+
+	public void setSslVerifyHostname(boolean sslVerifyHostname) {
+		this.sslVerifyHostname = sslVerifyHostname;
 	}
 
 	public String getSchemaAction() {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/RandomValuePropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/RandomValuePropertySource.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.env;
 
+import java.security.SecureRandom;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Random;
@@ -76,7 +77,7 @@ public class RandomValuePropertySource extends PropertySource<Random> {
 	}
 
 	public RandomValuePropertySource(String name) {
-		super(name, new Random());
+		super(name, new SecureRandom());
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/ApplicationPid.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/ApplicationPid.java
@@ -18,10 +18,13 @@ package org.springframework.boot.system;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
 
@@ -118,31 +121,31 @@ public class ApplicationPid {
 	 */
 	public void write(File file) throws IOException {
 		Assert.state(this.pid != null, "No PID available");
-		createParentDirectory(file);
-		if (file.exists()) {
-			assertCanOverwrite(file);
+		Path path = file.toPath();
+		createParentDirectory(path);
+		if (Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+			assertCanOverwrite(path);
 		}
-		try (FileWriter writer = new FileWriter(file)) {
-			writer.append(this.pid);
-		}
+		Files.write(path, this.pid.getBytes(StandardCharsets.UTF_8), StandardOpenOption.TRUNCATE_EXISTING,
+				StandardOpenOption.CREATE, LinkOption.NOFOLLOW_LINKS);
 	}
 
-	private void createParentDirectory(File file) {
-		File parent = file.getParentFile();
+	private void createParentDirectory(Path path) throws IOException {
+		Path parent = path.getParent();
 		if (parent != null) {
-			parent.mkdirs();
+			Files.createDirectories(parent);
 		}
 	}
 
-	private void assertCanOverwrite(File file) throws IOException {
-		if (!file.canWrite() || !canWritePosixFile(file)) {
+	private void assertCanOverwrite(Path file) throws IOException {
+		if (!Files.isWritable(file) || !canWritePosixFile(file)) {
 			throw new FileNotFoundException(file.toString() + " (permission denied)");
 		}
 	}
 
-	private boolean canWritePosixFile(File file) throws IOException {
+	private boolean canWritePosixFile(Path file) throws IOException {
 		try {
-			Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(file.toPath());
+			Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(file, LinkOption.NOFOLLOW_LINKS);
 			for (PosixFilePermission permission : WRITE_PERMISSIONS) {
 				if (permissions.contains(permission)) {
 					return true;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/ApplicationTemp.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/ApplicationTemp.java
@@ -18,13 +18,17 @@ package org.springframework.boot.system;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
 import java.security.MessageDigest;
 import java.util.EnumSet;
 
@@ -50,6 +54,8 @@ public class ApplicationTemp {
 
 	private final Class<?> sourceClass;
 
+	private final UserPrincipal directoryOwner;
+
 	private volatile Path path;
 
 	/**
@@ -65,6 +71,22 @@ public class ApplicationTemp {
 	 */
 	public ApplicationTemp(Class<?> sourceClass) {
 		this.sourceClass = sourceClass;
+		this.directoryOwner = directoryOwner();
+	}
+
+	private static UserPrincipal directoryOwner() {
+		try {
+			Path tempFile = Files.createTempFile("application-temp", "-owner");
+			UserPrincipal owner = Files.getOwner(tempFile);
+			Files.delete(tempFile);
+			return owner;
+		}
+		catch (UnsupportedOperationException ex) {
+			return null;
+		}
+		catch (IOException ex) {
+			throw new UncheckedIOException(ex);
+		}
 	}
 
 	@Override
@@ -101,8 +123,28 @@ public class ApplicationTemp {
 
 	private Path createDirectory(Path path) {
 		try {
-			if (!Files.exists(path)) {
-				Files.createDirectory(path, getFileAttributes(path.getFileSystem(), DIRECTORY_PERMISSIONS));
+			FileSystem fileSystem = path.getFileSystem();
+			if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+				Files.createDirectory(path, asFileAttributes(fileSystem, DIRECTORY_PERMISSIONS));
+			}
+			else {
+				if (supportsPosixView(fileSystem)) {
+					PosixFileAttributes attributes = Files.readAttributes(path, PosixFileAttributes.class,
+							LinkOption.NOFOLLOW_LINKS);
+					Assert.state(attributes.isDirectory(),
+							() -> "'" + path + "' already exists but it is not a directory");
+					Assert.state(DIRECTORY_PERMISSIONS.equals(attributes.permissions()), () -> "Existing directory '"
+							+ path + "' does not have the permissions " + DIRECTORY_PERMISSIONS);
+					assertDirectoryOwnership(attributes.owner(), path);
+				}
+				else {
+					try {
+						assertDirectoryOwnership(Files.getOwner(path, LinkOption.NOFOLLOW_LINKS), path);
+					}
+					catch (UnsupportedOperationException ex) {
+						// Ownership check not supported. Continue.
+					}
+				}
 			}
 			return path;
 		}
@@ -111,11 +153,20 @@ public class ApplicationTemp {
 		}
 	}
 
-	private FileAttribute<?>[] getFileAttributes(FileSystem fileSystem, EnumSet<PosixFilePermission> ownerReadWrite) {
-		if (!fileSystem.supportedFileAttributeViews().contains("posix")) {
+	private void assertDirectoryOwnership(UserPrincipal owner, Path path) {
+		Assert.state((this.directoryOwner == null) || this.directoryOwner.equals(owner),
+				() -> "Existing directory '" + path + "' is not owned by " + this.directoryOwner.getName());
+	}
+
+	private FileAttribute<?>[] asFileAttributes(FileSystem fileSystem, EnumSet<PosixFilePermission> ownerReadWrite) {
+		if (!supportsPosixView(fileSystem)) {
 			return NO_FILE_ATTRIBUTES;
 		}
 		return new FileAttribute<?>[] { PosixFilePermissions.asFileAttribute(ownerReadWrite) };
+	}
+
+	private boolean supportsPosixView(FileSystem fileSystem) {
+		return fileSystem.supportedFileAttributeViews().contains("posix");
 	}
 
 	private Path getTempDirectory() {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/RandomValuePropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/RandomValuePropertySourceTests.java
@@ -49,7 +49,7 @@ class RandomValuePropertySourceTests {
 
 	@Test
 	void getPropertyWhenStringReturnsValue() {
-		assertThat(this.source.getProperty("random.string")).isNotNull();
+		assertThat(this.source.getProperty("random.string")).isNotNull().asString().containsPattern("^[0-9a-f]{32}$");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/system/ApplicationPidTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/system/ApplicationPidTests.java
@@ -17,11 +17,18 @@
 package org.springframework.boot.system;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.contentOf;
 
@@ -68,6 +75,40 @@ class ApplicationPidTests {
 		file.delete();
 		pid.write(file);
 		assertThat(contentOf(file)).isEqualTo("123");
+	}
+
+	@Test
+	void overwriteExistingPid() throws Exception {
+		File file = new File(this.tempDir, "pid");
+		new ApplicationPid("123").write(file);
+		assertThat(contentOf(file)).isEqualTo("123");
+		new ApplicationPid("456").write(file);
+		assertThat(contentOf(file)).isEqualTo("456");
+	}
+
+	@Test
+	@DisabledOnOs(OS.WINDOWS)
+	void whenSymlinkToNonExistentTargetExistsAtPidFileLocationWriteThrows() throws IOException {
+		File link = new File(this.tempDir, "pid");
+		File target = new File(this.tempDir, "target");
+		Files.createSymbolicLink(link.toPath(), target.toPath());
+		ApplicationPid pid = new ApplicationPid("123");
+		assertThatIOException().isThrownBy(() -> pid.write(link));
+		assertThat(Files.isSymbolicLink(link.toPath())).isTrue();
+		assertThat(target).doesNotExist();
+	}
+
+	@Test
+	@DisabledOnOs(OS.WINDOWS)
+	void whenSymlinkToTargetExistsAtPidFileLocationWriteThrows() throws IOException {
+		File link = new File(this.tempDir, "pid");
+		Path target = new File(this.tempDir, "target").toPath();
+		Files.write(target, "target".getBytes(), StandardOpenOption.CREATE_NEW);
+		Files.createSymbolicLink(link.toPath(), target);
+		ApplicationPid pid = new ApplicationPid("123");
+		assertThatIOException().isThrownBy(() -> pid.write(link));
+		assertThat(Files.isSymbolicLink(link.toPath())).isTrue();
+		assertThat(target).hasContent("target");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/system/ApplicationTempTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/system/ApplicationTempTests.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
 import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.util.FileSystemUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
  * Tests for {@link ApplicationTemp}.
@@ -83,6 +85,29 @@ class ApplicationTempTests {
 			assertDirectoryPermissions(path);
 			assertDirectoryPermissions(temp.getDir("sub").toPath());
 		}
+	}
+
+	@Test
+	void whenDirectoryExistsWithWrongPermissionsGetDirThrows() throws IOException {
+		ApplicationTemp temp = new ApplicationTemp();
+		Path path = temp.getDir().toPath();
+		Files.getFileAttributeView(path, PosixFileAttributeView.class)
+			.setPermissions(EnumSet.allOf(PosixFilePermission.class));
+		assertThatIllegalStateException().isThrownBy(new ApplicationTemp()::getDir)
+			.withMessageContaining("does not have the permissions");
+		FileSystemUtils.deleteRecursively(path);
+	}
+
+	@Test
+	void whenSymlinkExistsInDirectoryLocationGetDirThrows() throws IOException {
+		ApplicationTemp temp = new ApplicationTemp();
+		Path path = temp.getDir().toPath();
+		FileSystemUtils.deleteRecursively(path);
+		Path linkTarget = Files.createTempDirectory("application-test-tests");
+		Files.createSymbolicLink(path, linkTarget);
+		assertThatIllegalStateException().isThrownBy(new ApplicationTemp()::getDir)
+			.withMessageContaining("already exists but it is not a directory");
+		FileSystemUtils.deleteRecursively(path);
 	}
 
 	private void assertDirectoryPermissions(Path path) throws IOException {


### PR DESCRIPTION
## Summary                                                                                                                                                                                  
  Adds five Spring Boot CVE fixes on top of the 2.7.18-rxlogix-2 baseline                                                                                                                     
  (PVADMIN-49830 — already published to Nexus). Bumps version to                                                                                                                              
  2.7.18-rxlogix-3.                                                                                                                                                                           
                                                                                                                                                                                              
  Of the five CVEs:                                                                                                                                                                           
  - 4 produce real code fixes on this fork (cherry-pick or manual port).                                                                                                                      
  - 1 (CVE-2026-40971) does not apply to Spring Boot 2.7.x (no SSL bundle                                                                                                                     
    abstraction); recorded in the registry and documented via an empty                                                                                                                        
    marker commit so every CVE in the wave has audit trail.                                                                                                                                   
                                                                                                                                                                                              
  This PR is stacked on top of PVADMIN-49830. Merging order: PVADMIN-49830 → PVADMIN-49853.                                                                                                   
                                                                                                                                                                                              
  ## CVE details                                                                                                                                                                              
                                                                                                                                                                                              
  ### CVE-2026-40973 — ApplicationTemp predictable directory pre-creation                                                                                                                     
  - **Severity:** HIGH (CVSS v4.0 7.3) · spring-boot < 3.5.14
  - **Upstream fix:** [5ceb1a22893](https://github.com/spring-projects/spring-boot/commit/5ceb1a228932e35cc803d1c1fea68f0f984aaa90)                                                           
  - **Strategy:** cherry-pick. Dropped unrelated upstream `pathLock` field.                                                                                                                   
  - [Snyk](https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKBOOT-16198880) · [Spring](https://spring.io/security/cve-2026-40973)                                                     
                                                                                                                                                                                              
  ### CVE-2026-40977 — ApplicationPid follows symlinks when writing PID file                                                                                                                  
  - **Severity:** MEDIUM (CVSS v4.0 5.7) · spring-boot < 3.5.14                                                                                                                               
  - **Upstream fix:** [f533a4549c3](https://github.com/spring-projects/spring-boot/commit/f533a4549c3999aac30cb5830f07dc304933e93d)                                                           
  - **Strategy:** cherry-pick + adapt. Replaced `Files.writeString` (Java 11+) with `Files.write(path, pid.getBytes(UTF_8), opts...)` (Java 7+). Dropped tests using non-2.7 ApplicationPid   
  - [Snyk](https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKBOOT-16201011) · [Spring](https://spring.io/security/cve-2026-40977)                                                     
                                                                                                                                                                                              
  ### CVE-2026-40975 — RandomValuePropertySource uses non-secure PRNG                                                                                                                         
  - **Severity:** MEDIUM (CVSS v4.0 6.3) · spring-boot < 3.5.14      
  - **Upstream fix:** [f3b8eb0f2cd](https://github.com/spring-projects/spring-boot/commit/f3b8eb0f2cd989dffe5dceefce80bde165328b31)                                                           
  - **Strategy:** cherry-pick. Dropped Java-17 `HexFormat` import the upstream diff dragged in but the fork doesn't use.                                                                      
  - [Snyk](https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKBOOT-16191649) · [Spring](https://spring.io/security/cve-2026-40975)                                                     
                                                                                                                                                                                              
  ### CVE-2026-40974 — Cassandra SSL hostname verification disabled                                                                                                                           
  - **Severity:** LOW (CVSS v4.0 2.3) · spring-boot-autoconfigure < 3.5.14                                                                                                                    
  - **Upstream fix:** [e22083a5684](https://github.com/spring-projects/spring-boot/commit/e22083a5684c3c65bcf2a9a90adcdecee6e85d50)                                                           
  - **Strategy:** **manual port** — fork's Cassandra SSL config is structurally different (flat `boolean ssl`, no `SslBundle`, no `Ssl` nested properties class). Added top-level             
  `spring.data.cassandra.ssl-verify-hostname` property (default `true`); switched `configureSsl` from `withSslContext(SSLContext.getDefault())` to `withSslEngineFactory(new                  
  ProgrammaticSslEngineFactory(SSLContext.getDefault(), null, properties.isSslVerifyHostname()))`. 3-arg ctor available in DataStax driver 4.14.1.                                            
  - [Snyk](https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKBOOT-16191022) · [Spring](https://spring.io/security/cve-2026-40974)                                                     
                                                                                                                                                                                              
  ### CVE-2026-40971 — RabbitMQ verify-hostname inconsistently applied with SSL bundles                                                                                                       
  - **Status:** Not applicable to Spring Boot 2.7.x — no fix back-ported; empty marker commit on the branch.                                                                                  
  - **Why:** Spring's official advisory lists only 4.0.x and 3.5.x as affected. The vulnerability requires an `SslBundle` to be configured; SSL bundles were introduced in Spring Boot 3.1 and
   don't exist on this fork. The fork's existing 2.7 `RabbitConnectionFactoryBeanConfigurer` already calls `setEnableHostnameVerification(ssl.getVerifyHostname())` inside its SSL-enabled    
  block.                                                                                                                                                                                      
  - The CVE-tracking registry entry was added (with `2.7.18-rxlogix-3` as fix-version) so Snyk stops flagging it; safe to remove later once Snyk recognizes 2.7.x as not-affected.            
  - [Snyk](https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKBOOT-16200231) · [Spring](https://spring.io/security/cve-2026-40971)                                                     
                                                                                                                                                                                              
  ## Test plan                                                                                                                                                                                
  - [x] Targeted (JDK 11) — all 4 modules touched are green:                                                                                                                                  
    - `RandomValuePropertySourceTests` 21/21                                                                                                                                                  
    - `ApplicationTempTests` 6/6                                                                                                                                                              
    - `ApplicationPidTests` 9/9 (incl. new symlink tests)                                                                                                                                     
    - `Cassandra*Tests` 23/23 across 4 classes                                                                                                                                                
  - [x] `git range-diff` against each upstream cherry-pick — only documented adaptations; no security logic dropped.                                                                          
                                                                                                                                                                                              
  ## Ticket                                                                                                                                                                                   
  - Jira: https://rxlogixdev.atlassian.net/browse/PVADMIN-49853                                                                                                                               
  - Parent epic: https://rxlogixdev.atlassian.net/browse/PVADMIN-49785                                                                                                                        
  - Stacked on: PVADMIN-49830 (CVE-2026-22733, 2.7.18-rxlogix-2)  